### PR TITLE
Changes to BUSCO lineage parameter, added citations

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -1,5 +1,9 @@
 # Arcadia-Science/hifi2genome: Citations
 
+Below are Nextflow and pipeline-specific citations you should include when using results from this pipeline.
+
+# Nextflow citations
+
 ## [nf-core](https://pubmed.ncbi.nlm.nih.gov/32055031/)
 
 > Ewels PA, Peltzer A, Fillinger S, Patel H, Alneberg J, Wilm A, Garcia MU, Di Tommaso P, Nahnsen S. The nf-core framework for community-curated bioinformatics pipelines. Nat Biotechnol. 2020 Mar;38(3):276-278. doi: 10.1038/s41587-020-0439-x. PubMed PMID: 32055031.
@@ -8,11 +12,29 @@
 
 > Di Tommaso P, Chatzou M, Floden EW, Barja PP, Palumbo E, Notredame C. Nextflow enables reproducible computational workflows. Nat Biotechnol. 2017 Apr 11;35(4):316-319. doi: 10.1038/nbt.3820. PubMed PMID: 28398311.
 
-## Pipeline tools
+## [MultiQC](https://academic.oup.com/bioinformatics/article/32/19/3047/2196507)
 
-<!-- TODO: Fill citation information for external pipelines -->
+> Ewels P, Magnusson M, Lundin S, Kaller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct; 32(19):3047-3048. doi:10.1093/bioinformatics/btw354.
 
-## Software packaging/containerisation tools
+# Specific Pipeline tools
+
+## [Flye][https://www.nature.com/articles/s41587-019-0072-8]
+
+> Kolmogorov M, Yuan J, Lin Y, Pevzner P. Assembly of long, error-prone reads using repeat graphs. Nature Biotechnology. 2019; 540-546. doi:10.1038/s41587-019-0072-8
+
+## [BUSCO](https://academic.oup.com/bioinformatics/article/31/19/3210/211866)
+
+> Simao F, Waterhouse R, Ionnidis P, Kriventseva E, Zdobnov E. BUSCO: assessing genome assembly and annotation completeness with single-copy orthologs. Bioinformatics. Oct 2015; 31(19): 3210-3212. doi:10.1093/bioinformatics/btv351
+
+## [minimap2](https://academic.oup.com/bioinformatics/article/34/18/3094/4994778)
+
+> Li H. Minimap2: pairwise alignment for nucleotide sequences. Bioinformatics. Sept 2018; 34(18): 3094-3100
+
+## [QUAST](https://academic.oup.com/bioinformatics/article/29/8/1072/228832?login=false)
+
+> Gurevich A, Saveliev V, Vyahhi N, Tesler G. QUAST: quality assessment tool for genome assemblies. Bioinformatics. April 2013; 29(8): 1072-1075. doi:10.1093/bioinformatics/btt086
+
+# Software packaging/containerisation tools
 
 - [Docker](https://dl.acm.org/doi/10.5555/2600239.2600241)
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -28,8 +28,8 @@ process {
         time   = { check_max( 4.h   * task.attempt, 'time'    ) }
     }
     withLabel:process_medium {
-        cpus   = { check_max( 12     * task.attempt, 'cpus'    ) }
-        memory = { check_max( 65.GB * task.attempt, 'memory'  ) }
+        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
+        memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
         time   = { check_max( 8.h   * task.attempt, 'time'    ) }
     }
     withLabel:process_high {

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -16,5 +16,5 @@ params {
 
     // Input data for full size test
     input   = 'https://raw.githubusercontent.com/Arcadia-Science/test-datasets/main/hifi2genome/samplesheet_full_test.csv'
-    lineage = 'auto' // test the auto functionality
+    lineage = 'bacteria' // tests with general bacteria lineage for full dataset of 24 bacterial isolates from PacBio datasets site
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,7 +82,7 @@ The following are command-line arguments that are specific to the pipeline that 
 
 #### `--lineage`
 
-The selected BUSCO lineage to run for resulting genome assemblies. By default the lineage is set to `auto` to run auto lineage detection instead of a predetermined lineage set.
+The selected BUSCO lineage to run for resulting genome assemblies. This is a required parameter and is not set to a default setting. We highly recommonded NOT using the 'auto' lineage selection as in our experience this is highly resource intensive and is unnecessary for this workflow where the user likely already knows the desired lineage of the resulting assembly. See [https://busco.ezlab.org/list_of_lineages.html](https://busco.ezlab.org/list_of_lineages.html) for a full list of BUSCO lineages to choose from.
 
 #### `--mode`
 

--- a/modules/local/nf-core-modified/busco/main.nf
+++ b/modules/local/nf-core-modified/busco/main.nf
@@ -1,6 +1,6 @@
 process BUSCO {
     tag "$meta.id"
-    label 'process_high_memory' // auto lineage requires higher memory
+    label 'process_medium' // required lineage input parameter lower mem requirements than full auto selection
 
     conda "bioconda::busco=5.4.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
 
     // Max resource options
     // Defaults only, expecting to be overwritten
-    max_memory                 = '650.GB'
+    max_memory                 = '400.GB'
     max_cpus                   = 36
     max_time                   = '240.h'
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,7 +19,7 @@ params {
     multiqc_methods_description = null
 
     // BUSCO options
-    lineage                    = 'auto'
+    lineage                    = null
     mode                       = 'genome'
 
     // Boilerplate options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -16,7 +16,8 @@
                     "help_text": "You will need to design a file with information about the sample in your experiment before running the pipeline. Use this parameter to specify the location of the file. It has to be comma-separated."
                 },
                 "outdir": {
-                    "type": "string"
+                    "type": "string",
+                    "default": null
                 }
             },
             "required": ["input", "outdir"]

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -31,13 +31,16 @@
             "properties": {
                 "lineage": {
                     "type": "string",
-                    "default": "auto"
+                    "default": "null",
+                    "description": "Lineage to run against resulting assemblies. You must provide a lineage listed in https://busco.ezlab.org/list_of_lineages.html. We highly recommend selecting a lineage instead of running in 'auto' mode as this is resource intensive."
                 },
                 "mode": {
                     "type": "string",
-                    "default": "genome"
+                    "default": "genome",
+                    "description": "Mode for BUSCO to run in. Default is genome and should always be ran that way for the purposes of this workflow"
                 }
-            }
+            },
+            "required": ["lineage"]
         },
         "email_options": {
             "title": "Email options",
@@ -162,12 +165,12 @@
             "properties": {
                 "multiqc_title": {
                     "type": "string",
-                    "default": null,
+                    "default": "None",
                     "hidden": true
                 },
                 "multiqc_logo": {
                     "type": "string",
-                    "default": null,
+                    "default": "None",
                     "hidden": true
                 },
                 "max_multiqc_email_size": {
@@ -177,12 +180,12 @@
                 },
                 "multiqc_methods_description": {
                     "type": "string",
-                    "default": null,
+                    "default": "None",
                     "hidden": true
                 },
                 "multiqc_config": {
                     "type": "string",
-                    "default": null,
+                    "default": "None",
                     "hidden": true
                 }
             }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -9,16 +9,14 @@
             "title": "input_output_options",
             "type": "object",
             "description": "Define where the pipeline should find input data and save output data",
-            "default": "",
+            "default": null,
             "properties": {
                 "input": {
                     "type": "string",
-                    "default": "null",
                     "help_text": "You will need to design a file with information about the sample in your experiment before running the pipeline. Use this parameter to specify the location of the file. It has to be comma-separated."
                 },
                 "outdir": {
-                    "type": "string",
-                    "default": "null"
+                    "type": "string"
                 }
             },
             "required": ["input", "outdir"]
@@ -27,11 +25,10 @@
             "title": "busco_options",
             "type": "object",
             "description": "",
-            "default": "",
+            "default": null,
             "properties": {
                 "lineage": {
                     "type": "string",
-                    "default": "null",
                     "description": "Lineage to run against resulting assemblies. You must provide a lineage listed in https://busco.ezlab.org/list_of_lineages.html. We highly recommend selecting a lineage instead of running in 'auto' mode as this is resource intensive."
                 },
                 "mode": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -29,6 +29,7 @@
             "properties": {
                 "lineage": {
                     "type": "string",
+                    "default": null,
                     "description": "Lineage to run against resulting assemblies. You must provide a lineage listed in https://busco.ezlab.org/list_of_lineages.html. We highly recommend selecting a lineage instead of running in 'auto' mode as this is resource intensive."
                 },
                 "mode": {
@@ -162,12 +163,12 @@
             "properties": {
                 "multiqc_title": {
                     "type": "string",
-                    "default": "None",
+                    "default": null,
                     "hidden": true
                 },
                 "multiqc_logo": {
                     "type": "string",
-                    "default": "None",
+                    "default": null,
                     "hidden": true
                 },
                 "max_multiqc_email_size": {
@@ -177,12 +178,12 @@
                 },
                 "multiqc_methods_description": {
                     "type": "string",
-                    "default": "None",
+                    "default": null,
                     "hidden": true
                 },
                 "multiqc_config": {
                     "type": "string",
-                    "default": "None",
+                    "default": null,
                     "hidden": true
                 }
             }

--- a/tower.yml
+++ b/tower.yml
@@ -1,0 +1,3 @@
+reports:
+  multiqc_report.html:
+    display: "MultiQC HTML report"


### PR DESCRIPTION
This PR changes the BUSCO lineage parameter to be a required parameter and not have a default value. This also changes the resource requirements to be lower since a selected lineage for this parameter is less memory hungry than the "auto" mode lineage selection. This includes additions to the documentation to point the user to the BUSCO lineage list and caution them not to use the auto mode. This PR also adds citations each tool used. This PR might be close to the final changes before cutting a release for putting the pub together (pending successful full test run). 
