### PR TITLE
Samtools stats and reporting added

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+test/*
 email_template.html
 .nextflow*
 work/

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -5,11 +5,14 @@ report_section_order:
     order: -1000
   busco:
     order: -1001
-  "Arcadia-Science-hifi2genome-methods-description":
+  Samtools:
     order: -1002
-  software_versions:
+  "Arcadia-Science-hifi2genome-methods-description":
     order: -1003
-  "Arcadia-Science-hifi2genome-summary":
+  software_versions:
     order: -1004
+  "Arcadia-Science-hifi2genome-summary":
+    order: -1005
 
 show_analysis_paths: False
+log_filesize_limit: 2000000000 # read larger files and not automatically skip

--- a/modules.json
+++ b/modules.json
@@ -20,6 +20,10 @@
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "ee80d14721e76e2e079103b8dcd5d57129e584ba"
+                    },
+                    "samtools/stats": {
+                        "branch": "master",
+                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c"
                     }
                 }
             }

--- a/modules/local/nf-core-modified/minimap2/align/main.nf
+++ b/modules/local/nf-core-modified/minimap2/align/main.nf
@@ -16,8 +16,8 @@ process MINIMAP2_ALIGN {
     tuple val(index_meta), path(index)
 
     output:
-    tuple val(meta), path("*.bam"), emit: bam
-    path "versions.yml"           , emit: versions
+    tuple val(meta), path("*.sorted.bam"), path("*.bam.bai")     , emit: sorted_indexed_bam
+    path "versions.yml"                                          , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -33,8 +33,8 @@ process MINIMAP2_ALIGN {
         $index \\
         $reads | \\
         samtools view -@ $task.cpus -bS | \\
-        samtools sort -@ $task.cpus -o ${prefix}.bam
-    samtools index ${prefix}.bam
+        samtools sort -@ $task.cpus -o ${prefix}.sorted.bam
+    samtools index ${prefix}.sorted.bam ${prefix}.bam.bai
 
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/samtools/stats/main.nf
+++ b/modules/nf-core/samtools/stats/main.nf
@@ -1,0 +1,49 @@
+process SAMTOOLS_STATS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::samtools=1.16.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samtools:1.16.1--h6899075_1' :
+        'quay.io/biocontainers/samtools:1.16.1--h6899075_1' }"
+
+    input:
+    tuple val(meta), path(input), path(input_index)
+    tuple val(meta_fasta), path(fasta)
+
+    output:
+    path("*.stats")                 , emit: stats
+    path  "versions.yml"            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference = fasta ? "--reference ${fasta}" : ""
+    """
+    samtools \\
+        stats \\
+        --threads ${task.cpus} \\
+        ${reference} \\
+        ${input} \\
+        > ${prefix}.stats
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.stats
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/samtools/stats/meta.yml
+++ b/modules/nf-core/samtools/stats/meta.yml
@@ -1,0 +1,53 @@
+name: samtools_stats
+description: Produces comprehensive statistics from SAM/BAM/CRAM file
+keywords:
+  - statistics
+  - counts
+  - bam
+  - sam
+  - cram
+tools:
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: hhttp://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - input:
+    type: file
+    description: BAM/CRAM file from alignment
+    pattern: "*.{bam,cram}"
+  - input_index:
+    type: file
+    description: BAI/CRAI file from alignment
+    pattern: "*.{bai,crai}"
+  - fasta:
+      type: optional file
+      description: Reference file the CRAM was created with
+      pattern: "*.{fasta,fa}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - stats:
+      type: file
+      description: File containing samtools stats output
+      pattern: "*.{stats}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@drpatelh"
+  - "@FriederikeHanssen"

--- a/subworkflows/local/minimap2_subworkflow.nf
+++ b/subworkflows/local/minimap2_subworkflow.nf
@@ -4,6 +4,7 @@
 
 include { MINIMAP2_INDEX } from '../../modules/nf-core/minimap2/index'
 include { MINIMAP2_ALIGN } from '../../modules/local/nf-core-modified/minimap2/align'
+include { SAMTOOLS_STATS } from '../../modules/nf-core/samtools/stats/main'
 
 workflow MINIMAP2_SUBWORKFLOW {
     take:
@@ -20,11 +21,17 @@ workflow MINIMAP2_SUBWORKFLOW {
 
     // align reads to index
     MINIMAP2_ALIGN(reads, ch_index)
-    ch_align_bam = MINIMAP2_ALIGN.out.bam
+    ch_align_bam = MINIMAP2_ALIGN.out.sorted_indexed_bam
+
+    // get samtools stats
+    SAMTOOLS_STATS(ch_align_bam, assembly)
+    ch_stats = SAMTOOLS_STATS.out.stats
+    ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions)
 
     emit:
     ch_index
     ch_align_bam
+    ch_stats
     versions = ch_versions
 
 }

--- a/workflows/hifi2genome.nf
+++ b/workflows/hifi2genome.nf
@@ -103,6 +103,7 @@ workflow HIFI2GENOME {
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(BUSCO.out.short_summaries_txt.collect{it[1]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.results.collect().ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(MINIMAP2_SUBWORKFLOW.out.ch_stats.collect().ifEmpty([]))
 
     MULTIQC(
         ch_multiqc_files.collect(),


### PR DESCRIPTION
This PR adds support for `samtools stats` and subsequent reporting with multiqc for % mapping rate and alignment metrics. Identical to additions in metagenomics workflow in https://github.com/Arcadia-Science/metagenomics/pull/39 
