### PR TITLE
Fix 1:1 mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,5 @@ The `nf-core` template was used as a guideline for putting this workflow togethe
 
 > **The nf-core framework for community-curated bioinformatics pipelines.**
 > Ewels PA, Peltzer A, Fillinger S, Patel H, Alneberg J, Wilm A, Garcia MU, Di Tommaso P, Nahnsen S. The nf-core framework for community-curated bioinformatics pipelines. (2020). [doi: 10.1038/s41587-020-0439-x](https://doi.org/10.1038/s41587-020-0439-x)
+
 > An extensive list of references for the tools used by the pipeline can be found in the [`CITATIONS.md`](CITATIONS.md) file.

--- a/modules/local/nf-core-modified/minimap2/align/main.nf
+++ b/modules/local/nf-core-modified/minimap2/align/main.nf
@@ -1,5 +1,5 @@
 process MINIMAP2_ALIGN {
-    tag "$index_meta.id"
+    tag "$meta.id"
     label 'process_medium'
 
     // Note: the versions here need to match the versions used in the mulled container below and minimap2/index
@@ -12,10 +12,10 @@ process MINIMAP2_ALIGN {
     // fixes samtools piping to go through view, sort, and index to a final BAM file
 
     input:
-    tuple val(index_meta), path(index), val(reads_meta), path(reads)
+    tuple val(meta), path(index), path(reads)
 
     output:
-    tuple val(index_meta), path("*.sorted.bam"), path("*.bam.bai")     , emit: sorted_indexed_bam
+    tuple val(meta), path("*.sorted.bam"), path("*.bam.bai")     , emit: sorted_indexed_bam
     path "versions.yml"                                                , emit: versions
 
     when:
@@ -23,7 +23,7 @@ process MINIMAP2_ALIGN {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${index_meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
     minimap2 \\

--- a/modules/local/nf-core-modified/minimap2/align/main.nf
+++ b/modules/local/nf-core-modified/minimap2/align/main.nf
@@ -1,5 +1,5 @@
 process MINIMAP2_ALIGN {
-    tag "$meta.id"
+    tag "$index_meta.id"
     label 'process_medium'
 
     // Note: the versions here need to match the versions used in the mulled container below and minimap2/index
@@ -12,19 +12,18 @@ process MINIMAP2_ALIGN {
     // fixes samtools piping to go through view, sort, and index to a final BAM file
 
     input:
-    tuple val(meta), path(reads)
-    tuple val(index_meta), path(index)
+    tuple val(index_meta), path(index), val(reads_meta), path(reads)
 
     output:
-    tuple val(meta), path("*.sorted.bam"), path("*.bam.bai")     , emit: sorted_indexed_bam
-    path "versions.yml"                                          , emit: versions
+    tuple val(index_meta), path("*.sorted.bam"), path("*.bam.bai")     , emit: sorted_indexed_bam
+    path "versions.yml"                                                , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "${index_meta.id}"
 
     """
     minimap2 \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -34,7 +34,7 @@ params {
     help                       = false
     validate_params            = true
     show_hidden_params         = false
-    schema_ignore_params       = 'genomes'
+    schema_ignore_params       = "config_profile_name,config_profile_url,config_profile_contact,config_profile_description,custom_config_base,custom_config_version,enable_conda,genomes,hook_url"
 
 
     // Config options

--- a/subworkflows/local/minimap2_subworkflow.nf
+++ b/subworkflows/local/minimap2_subworkflow.nf
@@ -20,11 +20,7 @@ workflow MINIMAP2_SUBWORKFLOW {
     ch_index = MINIMAP2_INDEX.out.index
 
     // match index to the corresponding reads
-    ch_reads = reads.map{meta, reads -> [meta.id, meta,reads]}
-    ch_mapping = ch_index
-        .map{meta, index -> [meta.id, meta, index]}
-        .combine(ch_reads, by:0)
-        .map{id, index_meta, index, reads_meta, reads -> [index_meta, index, reads_meta, reads]}
+    ch_mapping = ch_index.join(reads)
 
     // align reads to index
     MINIMAP2_ALIGN(ch_mapping)

--- a/subworkflows/local/minimap2_subworkflow.nf
+++ b/subworkflows/local/minimap2_subworkflow.nf
@@ -19,8 +19,16 @@ workflow MINIMAP2_SUBWORKFLOW {
     ch_versions = ch_versions.mix(MINIMAP2_INDEX.out.versions)
     ch_index = MINIMAP2_INDEX.out.index
 
+    // match index to the corresponding reads
+    ch_reads = reads.map{meta, reads -> [meta.id, meta,reads]}
+    ch_mapping = ch_index
+        .map{meta, index -> [meta.id, meta, index]}
+        .combine(ch_reads, by:0)
+        .map{id, index_meta, index, reads_meta, reads -> [index_meta, index, reads_meta, reads]}
+        .view()
+
     // align reads to index
-    MINIMAP2_ALIGN(reads, ch_index)
+    MINIMAP2_ALIGN(ch_mapping)
     ch_align_bam = MINIMAP2_ALIGN.out.sorted_indexed_bam
 
     // get samtools stats

--- a/subworkflows/local/minimap2_subworkflow.nf
+++ b/subworkflows/local/minimap2_subworkflow.nf
@@ -25,7 +25,6 @@ workflow MINIMAP2_SUBWORKFLOW {
         .map{meta, index -> [meta.id, meta, index]}
         .combine(ch_reads, by:0)
         .map{id, index_meta, index, reads_meta, reads -> [index_meta, index, reads_meta, reads]}
-        .view()
 
     // align reads to index
     MINIMAP2_ALIGN(ch_mapping)

--- a/workflows/hifi2genome.nf
+++ b/workflows/hifi2genome.nf
@@ -94,26 +94,26 @@ workflow HIFI2GENOME {
         ch_versions.unique().collectFile(name: 'collated_versions.yml')
     )
 
-//     // multiqc reporting
-//     workflow_summary = WorkflowHifi2Genome.paramsSummaryMultiqc(workflow, summary_params)
-//     ch_workflow_summary = Channel.value(workflow_summary)
+    // multiqc reporting
+    workflow_summary = WorkflowHifi2Genome.paramsSummaryMultiqc(workflow, summary_params)
+    ch_workflow_summary = Channel.value(workflow_summary)
 
-//     ch_multiqc_files = Channel.empty()
-//     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
-//     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-//     ch_multiqc_files = ch_multiqc_files.mix(BUSCO.out.short_summaries_txt.collect{it[1]}.ifEmpty([]))
-//     ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.results.collect().ifEmpty([]))
-//     ch_multiqc_files = ch_multiqc_files.mix(MINIMAP2_SUBWORKFLOW.out.ch_stats.collect().ifEmpty([]))
+    ch_multiqc_files = Channel.empty()
+    ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
+    ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
+    ch_multiqc_files = ch_multiqc_files.mix(BUSCO.out.short_summaries_txt.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.results.collect().ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(MINIMAP2_SUBWORKFLOW.out.ch_stats.collect().ifEmpty([]))
 
-//     MULTIQC(
-//         ch_multiqc_files.collect(),
-//         ch_multiqc_config.collect().ifEmpty([]),
-//         ch_multiqc_custom_config.collect().ifEmpty([]),
-//         ch_multiqc_logo.collect().ifEmpty([])
+    MULTIQC(
+        ch_multiqc_files.collect(),
+        ch_multiqc_config.collect().ifEmpty([]),
+        ch_multiqc_custom_config.collect().ifEmpty([]),
+        ch_multiqc_logo.collect().ifEmpty([])
 
-//     )
-//     multiqc_report = MULTIQC.out.report.toList()
-//     ch_versions = ch_versions.mix(MULTIQC.out.versions)
+    )
+    multiqc_report = MULTIQC.out.report.toList()
+    ch_versions = ch_versions.mix(MULTIQC.out.versions)
 }
 
 /*

--- a/workflows/hifi2genome.nf
+++ b/workflows/hifi2genome.nf
@@ -94,26 +94,26 @@ workflow HIFI2GENOME {
         ch_versions.unique().collectFile(name: 'collated_versions.yml')
     )
 
-    // multiqc reporting
-    workflow_summary = WorkflowHifi2Genome.paramsSummaryMultiqc(workflow, summary_params)
-    ch_workflow_summary = Channel.value(workflow_summary)
+//     // multiqc reporting
+//     workflow_summary = WorkflowHifi2Genome.paramsSummaryMultiqc(workflow, summary_params)
+//     ch_workflow_summary = Channel.value(workflow_summary)
 
-    ch_multiqc_files = Channel.empty()
-    ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
-    ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-    ch_multiqc_files = ch_multiqc_files.mix(BUSCO.out.short_summaries_txt.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.results.collect().ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(MINIMAP2_SUBWORKFLOW.out.ch_stats.collect().ifEmpty([]))
+//     ch_multiqc_files = Channel.empty()
+//     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
+//     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
+//     ch_multiqc_files = ch_multiqc_files.mix(BUSCO.out.short_summaries_txt.collect{it[1]}.ifEmpty([]))
+//     ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.results.collect().ifEmpty([]))
+//     ch_multiqc_files = ch_multiqc_files.mix(MINIMAP2_SUBWORKFLOW.out.ch_stats.collect().ifEmpty([]))
 
-    MULTIQC(
-        ch_multiqc_files.collect(),
-        ch_multiqc_config.collect().ifEmpty([]),
-        ch_multiqc_custom_config.collect().ifEmpty([]),
-        ch_multiqc_logo.collect().ifEmpty([])
+//     MULTIQC(
+//         ch_multiqc_files.collect(),
+//         ch_multiqc_config.collect().ifEmpty([]),
+//         ch_multiqc_custom_config.collect().ifEmpty([]),
+//         ch_multiqc_logo.collect().ifEmpty([])
 
-    )
-    multiqc_report = MULTIQC.out.report.toList()
-    ch_versions = ch_versions.mix(MULTIQC.out.versions)
+//     )
+//     multiqc_report = MULTIQC.out.report.toList()
+//     ch_versions = ch_versions.mix(MULTIQC.out.versions)
 }
 
 /*


### PR DESCRIPTION
This PR fixes #21 for queuing up mapping so that the corresponding reads that make up an assembly are mapped to the assembly to get mapping statistics, BAM files for downstream viewing etc. 
